### PR TITLE
Specify versions for build-depends

### DIFF
--- a/feature-creature.cabal
+++ b/feature-creature.cabal
@@ -20,15 +20,15 @@ library
                      , Products.Product
 
   build-depends:     base >=4.7 && < 5.0
-                     , bytestring
-                     , monad-logger
-                     , mtl
-                     , persistent
-                     , persistent-template
-                     , persistent-postgresql
-                     , text
-                     , time
-                     , transformers
+                     , bytestring >= 0.10.6.0 && < 0.11.0
+                     , monad-logger >= 0.3.14 && < 0.3.20 
+                     , mtl >= 2.2.1 && < 2.3
+                     , persistent >= 2.2 && < 2.3
+                     , persistent-template >= 2.1.3 && < 2.2
+                     , persistent-postgresql >= 2.2.1 && < 2.3
+                     , text >= 1.2 && < 1.3
+                     , time >= 1.5 && < 1.6
+                     , transformers >= 0.4.3 && < 0.4.4
 
   ghc-options:       -Wall
                      -fwarn-unused-matches 
@@ -39,9 +39,9 @@ library
   hs-source-dirs:    lib
 
 executable feature-creature
-  build-depends:     base >=4.7 && <4.8
+  build-depends:     base >=4.7 && < 5.0
                      , feature-creature
-                     , transformers
+                     , transformers >= 0.4.3 && < 0.4.4
 
   ghc-options:       -Wall
                      -fwarn-unused-matches 


### PR DESCRIPTION
It's hard to know what version of packages you have installed unless you specify it. This also prevents people who install the package at a later date to have different versions of the same packages. It is possible this will break your existing install of feature-creature. If it does blow away your sandbox, create a new one and run

``` haskell
 cabal install --force-reinstall
```

Note that forcing reinstalls is safe here because you're in a sandbox
