### PR TITLE
Integrate with elm

### DIFF
--- a/feature-creature.cabal
+++ b/feature-creature.cabal
@@ -67,6 +67,7 @@ executable feature-creature-web
                     , transformers
                     , transformers-compat
                     , wai
+                    , wai-extra
                     , warp
 
   ghc-options:       -Wall

--- a/lib/Products/Product.hs
+++ b/lib/Products/Product.hs
@@ -5,15 +5,16 @@ module Products.Product
   , findProducts
   , productRepositoryDir
   , toProduct
+  , toProductID
   , updateRepo
   ) where
 
   import CommonCreatures (WithErr)
-  import qualified Config as Cfg
+  import qualified Config                       as Cfg
   import Control.Monad.IO.Class (liftIO)
-  import qualified Data.Text as T
+  import qualified Data.Text                    as T
   import Database (runDB)
-  import qualified Database.Persist.Postgresql as DB
+  import qualified Database.Persist.Postgresql  as DB
   import GHC.Int (Int64)
   import qualified Git
   import Models
@@ -48,6 +49,9 @@ module Products.Product
   findProducts = do
     allProducts <- runDB $ DB.selectList ([] :: [DB.Filter Product]) []
     return $ allProducts
+
+  toProductID :: DB.Entity Product -> ProductID
+  toProductID dbEntity = DB.fromSqlKey . DB.entityKey $ dbEntity
 
   toProduct :: DB.Entity Product -> Product
   toProduct dbEntity = DB.entityVal dbEntity

--- a/web-executable/Documentation.hs
+++ b/web-executable/Documentation.hs
@@ -12,7 +12,7 @@ module Documentation where
   -- not sure of the type here. snippet taken from: http://haskell-servant.github.io/tutorial/docs.html
   documentationServer _ respond = respond $ responseLBS ok200 [plain] docsBS
     where
-      plain = ("Content-Type", "text/plain")
+      plain       = ("Content-Type", "text/plain")
 
   docsBS :: ByteString
   docsBS = encodeUtf8
@@ -21,4 +21,3 @@ module Documentation where
          $ SD.docsWithIntros [intro] productsAPI
     where
       intro = SD.DocIntro "feature-creature" ["![](http://www.homecinemachoice.com/sites/18/images/article_images_month/2012-07/universal%20monsters%20news%2001.jpg)", "Welcome to our API", "Feel free to dig around"]
-

--- a/web-executable/Main.hs
+++ b/web-executable/Main.hs
@@ -6,6 +6,7 @@ module Main where
   import ProductsAPI (ProductsAPI , productsServer)
   import Network.Wai
   import Network.Wai.Handler.Warp
+  import Network.Wai.Middleware.AddHeaders
   import Servant
 
   type FeatureCreatureAPI = ProductsAPI :<|> Raw
@@ -14,11 +15,14 @@ module Main where
   main = run 8081 app
 
   server :: Server FeatureCreatureAPI
-  server = productsServer 
+  server = productsServer
       :<|> Docs.documentationServer
 
   api :: Proxy FeatureCreatureAPI
   api = Proxy
 
+  addResponseHeaders :: Middleware
+  addResponseHeaders = addHeaders [("Access-Control-Allow-Origin", "*")]
+
   app :: Application
-  app = serve api server
+  app = addResponseHeaders $ serve api server

--- a/web-executable/ProductsAPI.hs
+++ b/web-executable/ProductsAPI.hs
@@ -29,10 +29,12 @@ module ProductsAPI
                                , repoUrl   :: T.Text 
                                } deriving (Show)
 
-  type Handler a = EitherT ServantErr IO a
+  type Handler a           = EitherT ServantErr IO a
 
-  type ProductsAPI = "products" :> Get '[JSON] [APIProduct]
-                :<|> "products" :> Capture "id" P.ProductID :> "features" :> Get '[JSON] DirectoryTree
+  type ProductsAPI = "products" :> ( Get '[JSON] [APIProduct]
+                                :<|> Capture "id" P.ProductID :> FeaturesAPI
+                                   )
+  type FeaturesAPI = "features" :> Get '[JSON] DirectoryTree
 
   instance ToJSON APIProduct where
     toJSON (APIProduct prodID prodName prodRepoUrl) = object ["id" .= prodID, "name" .= prodName, "repoUrl" .= prodRepoUrl]
@@ -44,7 +46,7 @@ module ProductsAPI
       ]
 
   instance SD.ToSample DirectoryTree DirectoryTree where
-    toSample _ = Just $ featureDirectoryExample
+    toSample _ = Just featureDirectoryExample
 
   instance SD.ToCapture (Capture "id" P.ProductID) where
     toCapture _ = SD.DocCapture "id" "Product id"


### PR DESCRIPTION
Resolves #28 

To integrate the Elm front-end application for local development:
- start an instance of feature-creature-web (default runs at `http://localhost:8081`)
- set the 'products' endpoint within the Elm application to `http://localhost:8081/products`
- use `elm-reactor` to start the elm webserver (default runs at `http://localhost:8000`)
- visit `http://localhost:8000/main.html` to view the Elm app backed with feature-creature-web data
