### PR TITLE
Add feature id to response

### DIFF
--- a/lib/Data/DirectoryTree.hs
+++ b/lib/Data/DirectoryTree.hs
@@ -22,19 +22,22 @@ module Data.DirectoryTree
   createNode file = Node file []
 
   addToDirectoryTree :: DirectoryTree -> FilePath -> DirectoryTree
-  addToDirectoryTree featureTree filePath = addToDirectoryTree' featureTree (splitFileName $ T.pack filePath)
-    where
-      splitFileName :: T.Text -> [T.Text]
-      splitFileName = (T.splitOn "/") . throwOutLeadingSlash 
+  addToDirectoryTree featureTree filePath =
+    addToDirectoryTree' featureTree filePathParts
+      where
+        filePathParts :: [T.Text]
+        filePathParts = (splitFileName $ T.pack filePath)
 
-      throwOutLeadingSlash :: T.Text -> T.Text
-      throwOutLeadingSlash txt
-        | (T.head txt) == '/' = T.tail txt
-        | otherwise           = txt
+        splitFileName :: T.Text -> [T.Text]
+        splitFileName = (T.splitOn "/") . throwOutLeadingSlash
+
+        throwOutLeadingSlash :: T.Text -> T.Text
+        throwOutLeadingSlash txt
+          | (T.head txt) == '/' = T.tail txt
+          | otherwise           = txt
 
   addToDirectoryTree' :: DirectoryTree -> [T.Text] -> DirectoryTree
   addToDirectoryTree' featureTree []                       = featureTree
-  addToDirectoryTree' (Node label forest) [file]           = Node label $ forest ++ [(createNode $ T.unpack file)]
   addToDirectoryTree' (Node label forest) (directory:rest) =
     let (matches, nonMatches) = partition (matchesLabel directory) forest in
         case matches of

--- a/lib/Features/Feature.hs
+++ b/lib/Features/Feature.hs
@@ -2,7 +2,7 @@
 
 module Features.Feature where
   import CommonCreatures (WithErr)
-  import Data.DirectoryTree (DirectoryTree, createNode, addToDirectoryTree)
+  import Data.DirectoryTree (DirectoryTree, FileDescription (..), createNode, addToDirectoryTree)
   import Data.List (stripPrefix)
   import Data.Maybe (mapMaybe)
   import Control.Monad.Except (throwError)
@@ -30,7 +30,7 @@ module Features.Feature where
   buildDirectoryTree = foldr (\featureFile dirTree -> addToDirectoryTree dirTree featureFile) rootNode
     where
       rootNode :: DirectoryTree
-      rootNode = createNode "featuresRoot"
+      rootNode = createNode $ FileDescription "featuresRoot" "featuresRoot"
 
   findFeatureFiles :: FilePath -> WithErr [FeatureFile]
   findFeatureFiles path = do

--- a/product-executable/CLI/FeaturesForm.hs
+++ b/product-executable/CLI/FeaturesForm.hs
@@ -1,6 +1,7 @@
 module CLI.FeaturesForm where
   import Control.Monad.Except (runExceptT)
-  import Data.Tree (drawTree)
+  import Data.DirectoryTree
+  import Data.Tree hiding (drawTree)
   import qualified Products.Product as P
   import qualified Features.Feature as F
   import Safe (readMay)
@@ -32,3 +33,16 @@ module CLI.FeaturesForm where
   showFeaturesCommandUsage :: IO ()
   showFeaturesCommandUsage = putStrLn "*** no documentation provided. sorry.***"
 
+  drawTree :: DirectoryTree -> String
+  drawTree  = unlines . draw
+
+  draw :: DirectoryTree -> [String]
+  draw (Node x ts0) = (show x) : drawSubTrees ts0
+    where
+      drawSubTrees [] = []
+      drawSubTrees [t] =
+          "|" : shift "`- " "   " (draw t)
+      drawSubTrees (t:ts) =
+          "|" : shift "+- " "|  " (draw t) ++ drawSubTrees ts
+
+      shift first other = zipWith (++) (first : repeat other)

--- a/web-executable/ProductsAPI.hs
+++ b/web-executable/ProductsAPI.hs
@@ -129,15 +129,15 @@ module ProductsAPI
   featureDirectoryExample :: DirectoryTree
   featureDirectoryExample = rootNode
     where
-      rootNode = Node "features" [creatures]
-      creatures = Node "creatures" [swampThing, wolfman]
-      swampThing = Node "swamp-thing" [
-        Node "vegetable-mind-control.feature" [],
-        Node "limb-regeneration.feature" []
+      rootNode = Node (FileDescription "features" "features") [creatures]
+      creatures = Node (FileDescription "creatures" "features/creatures") [swampThing, wolfman]
+      swampThing = Node (FileDescription "swamp-thing" "features/creatures/swamp-thing") [
+        Node (FileDescription "vegetable-mind-control.feature" "features/creatures/swamp-thing/vegetable-mind-control.feature") [],
+        Node (FileDescription "limb-regeneration.feature" "features/creatures/swamp-thing/limb-regeneration.feature") []
         ]
-      wolfman = Node "wolfman" [
-        Node "shape-shifting.feature" [],
-        Node "animal-instincts.feature" []
+      wolfman = Node (FileDescription "wolfman" "features/creatures/wolfman") [
+        Node (FileDescription "shape-shifting.feature" "features/creatures/wolfman/shape-shifting.feature") [],
+        Node (FileDescription "animal-instincts.feature" "features/creatures/wolfman/animal-instincts.feature") []
         ]
 
   featureFileSample :: F.Feature

--- a/web-executable/ProductsAPI.hs
+++ b/web-executable/ProductsAPI.hs
@@ -27,7 +27,7 @@ module ProductsAPI
 
   data APIProduct = APIProduct { productID :: P.ProductID
                                , name      :: T.Text
-                               , repoUrl   :: T.Text 
+                               , repoUrl   :: T.Text
                                } deriving (Show)
 
   data APIFeature = APIFeature { featureID :: F.FeatureFile
@@ -55,9 +55,9 @@ module ProductsAPI
              ]
 
   instance ToJSON APIFeature where
-    toJSON (APIFeature featureID description) =
-      object [ "featureID"     .= featureID
-             , "description" .= description
+    toJSON (APIFeature featID desc) =
+      object [ "featureID"   .= featID
+             , "description" .= desc
              ]
 
   instance SD.ToSample [APIProduct] [APIProduct] where
@@ -115,7 +115,7 @@ module ProductsAPI
       Right tree -> return tree
 
   productsFeature :: P.ProductID -> Maybe F.FeatureFile -> Handler APIFeature
-  productsFeature prodID Nothing = do
+  productsFeature _ Nothing = do
     error "Missing required query param 'path'"
   productsFeature prodID (Just path) = do
     prodDir <- liftIO $ P.productRepositoryDir prodID


### PR DESCRIPTION
Contains breaking API changes.
The tree data structure returned by the `/products/:id/features` endpoint now contains an FileDescription object as the Node's value.
The FileDescription (described below) contains a field, `filePath`, which can be used as a Feature's URI:

```
{ fileName :: String
, filePath :: String
}
```

Resolves #33 
